### PR TITLE
fix demo page for iOS

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -57,7 +57,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     
   </head>
   
-  <body unresolved>
+  <body unresolved touch-action="auto">
   
     <core-drawer-panel>
     


### PR DESCRIPTION
To get the demo to work on iOS, I needed to add the touch-action attribute and set it to auto.
