### PR TITLE
Make core-drawer-panel go fast using will-change

### DIFF
--- a/core-drawer-panel.css
+++ b/core-drawer-panel.css
@@ -22,6 +22,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   top: 0;
   left: 0;
   height: 100%;
+  will-change: transform;
   box-sizing: border-box;
   -mox-box-sizing: border-box;
 }
@@ -108,14 +109,14 @@ polyfill-next-selector { content: ':host .narrow-layout > #drawer > [drawer]'; }
 }
 
 .narrow-layout > #drawer:not(.core-selected) {
-  -webkit-transform: translate3d(-100%, 0, 0);
-  transform: translate3d(-100%, 0, 0);
+  -webkit-transform: translateX(-100%);
+  transform: translateX(-100%);
 }
 
 .right-drawer.narrow-layout > #drawer:not(.core-selected) {
   left: auto;
-  -webkit-transform: translate3d(100%, 0, 0);
-  transform: translate3d(100%, 0, 0);
+  -webkit-transform: translateX(100%);
+  transform: translateX(100%);
 }
 
 .narrow-layout > #main {

--- a/core-drawer-panel.html
+++ b/core-drawer-panel.html
@@ -165,10 +165,21 @@ To position the drawer to the right, add `rightDrawer` attribute.
     
     transition: false,
 
-    edgeSwipeSensitivity : 15,
+    edgeSwipeSensitivity: 15,
     
-    dragging : false,
-    
+    dragging: false,
+
+    // Whether the browser has support for the transform CSS property.
+    hasTransform: true,
+
+    // Whether the browser has support for the will-change CSS property.
+    hasWillChange: true,
+
+    created: function() {
+      this.hasTransform = 'transform' in this.style;
+      this.hasWillChange = 'willChange' in this.style;
+    },
+
     domReady: function() {
       // to avoid transition at the beginning e.g. page loads
       // NOTE: domReady is already raf delayed and delaying another frame
@@ -260,12 +271,22 @@ To position the drawer to the right, add `rightDrawer` attribute.
         }
       }
     },
+
+    transformForTranslateX: function (translateX) {
+      if (translateX === null)
+        return '';
+      return this.hasWillChange ? 'translateX(' + translateX + 'px)' : 'translate3d(' + translateX + 'px, 0, 0)';
+    },
     
     moveDrawer: function(translateX) {
       var s = this.$.drawer.style;
-      s.webkitTransform = s.transform = 
-          translateX === null ? '' : 'translate3d(' + translateX + 'px, 0, 0)';
-    }
+
+      if (this.hasTransform) {
+        s.transform = this.transformForTranslateX(translateX);
+      } else {
+        s.webkitTransform = this.transformForTranslateX(translateX);
+      }
+    },
 
   });
 


### PR DESCRIPTION
This patch teaches core-drawer-panel about the will-change CSS property. On an
element like the #drawer, we can hint to the browser that we're going to be
changing the transform property often by setting will-change: transform.

In this particular case, that causes the drawer to always be a stacking context
so that we don't trigger a layout at the end of the drawer opening animation.
Also, marking the drawer as will-change: transform keeps the open drawer in a
composited layer, which reduces repaints and hence latency when the user begins
dragging the drawer.

Finally, I've added feature detection for whether the browser supports the
unprefixed transform property. This change improves performance in browsers
that support both the prefixed and unprefixed transform properties because we
don't redundantly set both properties.
