### PR TITLE
Include transform in -webkit-transition

### DIFF
--- a/core-drawer-panel.css
+++ b/core-drawer-panel.css
@@ -28,7 +28,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 }
 
 .transition #drawer {
-  transition: -webkit-transform ease-in-out 0.3s, width ease-in-out 0.3s;
+  -webkit-transition: -webkit-transform ease-in-out 0.3s, transform ease-in-out 0.3s, width ease-in-out 0.3s;
   transition: transform ease-in-out 0.3s, width ease-in-out 0.3s;
 }
 


### PR DESCRIPTION
Currently, Chrome supports unprefixed transforms but not unprefixed
transitions. In order for the drawer to animate its transition, we need to list
the unprefixed transform property in -webkit-transition.
