### PR TITLE
Add "swipeAnywhere" attribute

### DIFF
--- a/core-drawer-panel.html
+++ b/core-drawer-panel.html
@@ -194,6 +194,15 @@ To position the drawer to the right, add `rightDrawer` attribute.
       disableSwipe: false,
       
       /**
+       * If true, you can open the drawer from a swipe in the middle of the screen.
+       *
+       * @attribute swipeAnywhere
+       * @type boolean
+       * @default false
+       */
+      swipeAnywhere: false,
+      
+      /**
        * If true, ignore `responsiveWidth` setting and force the narrow layout.
        *
        * @attribute forceNarrow
@@ -348,7 +357,7 @@ To position the drawer to the right, add `rightDrawer` attribute.
         this.dragging = true;
 
         if (this.isMainSelected()) {
-          this.dragging = this.peeking || this.isEdgeTouch(e);
+          this.dragging = this.peeking || this.isEdgeTouch(e) || this.swipeAnywhere;
         }
 
         if (this.dragging) {


### PR DESCRIPTION
This allows a drawer to be opened by swiping in the middle of the screen instead of just the edges.

Mobile Safari sends the browser back or forward on swipes originating from the edge of the screen, making it difficult if not impossible to open a drawer.