### PR TITLE
Added: attribute fullWindow

### DIFF
--- a/core-drawer-panel.css
+++ b/core-drawer-panel.css
@@ -158,3 +158,25 @@ polyfill-next-selector { content: 'core-selector:not(.narrow-layout) [core-drawe
 core-selector:not(.narrow-layout) ::content [core-drawer-toggle] {
   display: none;
 }
+
+/*
+fullWindow
+*/
+:host([fullWindow]) {
+  height: auto;
+}
+
+:host([fullWindow]) #main {
+  position: relative;
+  width: calc(100% - {{narrow ? '0' : drawerWidth}});
+}
+
+:host([fullWindow]) #drawer,
+:host([fullWindow]) #scrim {
+  position: fixed;
+}
+
+:host([fullWindow]) content[select="[main]"]::content [fullWindow]::shadow #headerContainer {
+  left: {{!narrow && !rightDrawer && drawerWidth}};
+  right: {{!narrow && rightDrawer && drawerWidth}};
+}

--- a/core-drawer-panel.html
+++ b/core-drawer-panel.html
@@ -126,6 +126,8 @@ To position the drawer to the right, add `rightDrawer` attribute.
      */
 
     publish: {
+      
+      fullWindow: {value: false, reflect: true},
 
       /**
        * Width of the drawer panel.


### PR DESCRIPTION
Can be used together with the corresponding pull request of core-scroll-header-panel.

The fullWindow attribute does not have to be set explicitly, this is done automatically by a core-scroll-header-panel in fullWindow mode.