### PR TITLE
[0.8] Fix toggling drawer when clicked element is in shady dom

### DIFF
--- a/core-drawer-panel.html
+++ b/core-drawer-panel.html
@@ -613,9 +613,10 @@ To position the drawer to the right, add `rightDrawer` attribute.
       // },
 
       onClick: function(e) {
-        var isTargetToggleElement = e.target &&
+        var target = Polymer.dom(e).localTarget;
+        var isTargetToggleElement = target &&
           this.drawerToggleAttribute &&
-          e.target.hasAttribute(this.drawerToggleAttribute);
+          target.hasAttribute(this.drawerToggleAttribute);
 
         if (isTargetToggleElement) {
           this.togglePanel();

--- a/test/basic.html
+++ b/test/basic.html
@@ -10,7 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
 <head>
   <meta charset="UTF-8">
-  <title>paper-icon-button basic tests</title>
+  <title>core-drawer-panel basic tests</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
@@ -26,7 +26,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <test-fixture id="DrawerPanelToggle">
     <template>
-      <core-drawer-panel>
+      <core-drawer-panel selected="main">
         <div drawer></div>
         <div main>
           <div core-drawer-toggle>Simple Toggle</div>
@@ -37,7 +37,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <test-fixture id="DrawerPanelCustomElementToggle">
     <template>
-      <core-drawer-panel>
+      <core-drawer-panel selected="main">
         <div drawer></div>
         <div main>
           <test-toggle core-drawer-toggle></test-toggle>
@@ -63,8 +63,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     test('toggles drawer when an element inside a host element with the "core-drawer-toggle" attribute is clicked', function() {
-      var toggle = d2.querySelector('[core-drawer-toggle] div');
-      toggle.dispatchEvent(new CustomEvent('click', {bubbles: true}));
+      var toggle = d2.querySelector('[core-drawer-toggle]');
+      var toggleChild =  (toggle.shadowRoot || toggle).querySelector('div')
+      toggleChild.dispatchEvent(new CustomEvent('click', {bubbles: true}));
       assert.strictEqual(d2.selected, 'drawer');
     });
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<!--
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>paper-icon-button basic tests</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../test-fixture/test-fixture-mocha.js"></script>
+
+  <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="../core-drawer-panel.html">
+  <link rel="import" href="test-elements.html">
+
+</head>
+<body>
+
+  <test-fixture id="DrawerPanelToggle">
+    <template>
+      <core-drawer-panel>
+        <div drawer></div>
+        <div main>
+          <div core-drawer-toggle>Simple Toggle</div>
+        </div>
+      </core-drawer-panel>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="DrawerPanelCustomElementToggle">
+    <template>
+      <core-drawer-panel>
+        <div drawer></div>
+        <div main>
+          <test-toggle core-drawer-toggle></test-toggle>
+        </div>
+      </core-drawer-panel>
+    </template>
+  </test-fixture>
+
+  <script>
+
+    var d1;
+    var d2;
+
+    setup(function() {
+      d1 = fixture('DrawerPanelToggle');
+      d2 = fixture('DrawerPanelCustomElementToggle');
+    });
+
+    test('toggles drawer when an element with "core-drawer-toggle" attribute is clicked', function() {
+      var toggle = d1.querySelector('[core-drawer-toggle]');
+      toggle.dispatchEvent(new CustomEvent('click', {bubbles: true}));
+      assert.strictEqual(d1.selected, 'drawer');
+    });
+
+    test('toggles drawer when an element inside a host element with the "core-drawer-toggle" attribute is clicked', function() {
+      var toggle = d2.querySelector('[core-drawer-toggle] div');
+      toggle.dispatchEvent(new CustomEvent('click', {bubbles: true}));
+      assert.strictEqual(d2.selected, 'drawer');
+    });
+
+  </script>
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<!--
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>Tests</title>
+  <script src="../../web-component-tester/browser.js"></script>
+</head>
+<body>
+  <script>
+    WCT.loadSuites([
+      'basic.html'
+    ]);
+  </script>
+</body>
+</html>

--- a/test/test-elements.html
+++ b/test/test-elements.html
@@ -1,0 +1,10 @@
+<dom-module id="test-toggle">
+  <template>
+    <div>Toggle</div>
+  </template>
+</dom-module>
+<script>
+Polymer({
+  is: "test-toggle"
+});
+</script>


### PR DESCRIPTION
I noticed this bug, while trying to use the `<paper-icon-button>` as the `core-drawer-toggle`.
On a click, `<core-drawer-panel>` was trying to find the `core-drawer-toggle` attribute on an element contained in the `<paper-icon-button>` and NOT the `<paper-icon-button>` itself.
